### PR TITLE
Refactor to use GUIDs (and fix asset rename/move)

### DIFF
--- a/Editor/AssetInfo.cs
+++ b/Editor/AssetInfo.cs
@@ -55,12 +55,6 @@ namespace Ogxd.ProjectCurator
             this.guid = guid;
         }
 
-        public string[] GetDependencies()
-        {
-            var path = AssetDatabase.GUIDToAssetPath(guid);
-            return AssetDatabase.GetDependencies(path, recursive: false);
-        }
-
         public void ClearIncludedStatus()
         {
             includedStatus = IncludedInBuild.Unknown;

--- a/Editor/AssetInfo.cs
+++ b/Editor/AssetInfo.cs
@@ -48,15 +48,16 @@ namespace Ogxd.ProjectCurator
         }
 
         [SerializeField]
-        public string path;
+        public string guid;
 
-        public AssetInfo(string path)
+        public AssetInfo(string guid)
         {
-            this.path = path;
+            this.guid = guid;
         }
 
         public string[] GetDependencies()
         {
+            var path = AssetDatabase.GUIDToAssetPath(guid);
             return AssetDatabase.GetDependencies(path, recursive: false);
         }
 
@@ -92,6 +93,7 @@ namespace Ogxd.ProjectCurator
 
             bool isInEditor = false;
 
+            string path = AssetDatabase.GUIDToAssetPath(guid);
             string[] directories = path.ToLower().Split('/');
             for (int i = 0; i < directories.Length - 1; i++) {
                 switch (directories[i]) {

--- a/Editor/AssetProcessor.cs
+++ b/Editor/AssetProcessor.cs
@@ -35,28 +35,31 @@ namespace Ogxd.ProjectCurator
             if (ProjectCuratorData.IsUpToDate) {
                 Actions.Enqueue(() => {
                     foreach (string path in paths) {
-                        var removedAsset = ProjectCurator.RemoveAssetFromDatabase(path);
-                        ProjectCurator.AddAssetToDatabase(path, removedAsset?.referencers);
+                        var guid = AssetDatabase.AssetPathToGUID(path);
+                        var removedAsset = ProjectCurator.RemoveAssetFromDatabase(guid);
+                        ProjectCurator.AddAssetToDatabase(guid, removedAsset?.referencers);
                     }
                 });
             }
             return paths;
         }
 
-        static void OnWillCreateAsset(string assetName)
+        static void OnWillCreateAsset(string assetPath)
         {
             if (ProjectCuratorData.IsUpToDate) {
+                var guid = AssetDatabase.AssetPathToGUID(assetPath);
                 Actions.Enqueue(() => {
-                    ProjectCurator.AddAssetToDatabase(assetName);
+                    ProjectCurator.AddAssetToDatabase(guid);
                 });
             }
         }
 
-        static AssetDeleteResult OnWillDeleteAsset(string assetName, RemoveAssetOptions removeAssetOptions)
+        static AssetDeleteResult OnWillDeleteAsset(string assetPath, RemoveAssetOptions removeAssetOptions)
         {
             if (ProjectCuratorData.IsUpToDate) {
+                var guid = AssetDatabase.AssetPathToGUID(assetPath);
                 Actions.Enqueue(() => {
-                    ProjectCurator.RemoveAssetFromDatabase(assetName);
+                    ProjectCurator.RemoveAssetFromDatabase(guid);
                 });
             }
             return AssetDeleteResult.DidNotDelete;
@@ -64,12 +67,6 @@ namespace Ogxd.ProjectCurator
 
         static AssetMoveResult OnWillMoveAsset(string sourcePath, string destinationPath)
         {
-            if (ProjectCuratorData.IsUpToDate) {
-                Actions.Enqueue(() => {
-                    ProjectCurator.RemoveAssetFromDatabase(sourcePath);
-                    ProjectCurator.AddAssetToDatabase(destinationPath);
-                });
-            }
             return AssetMoveResult.DidNotMove;
         }
     }

--- a/Editor/AssetProcessor.cs
+++ b/Editor/AssetProcessor.cs
@@ -47,9 +47,11 @@ namespace Ogxd.ProjectCurator
         static void OnWillCreateAsset(string assetPath)
         {
             if (ProjectCuratorData.IsUpToDate) {
-                var guid = AssetDatabase.AssetPathToGUID(assetPath);
                 Actions.Enqueue(() => {
-                    ProjectCurator.AddAssetToDatabase(guid);
+                    var guid = AssetDatabase.AssetPathToGUID(assetPath);
+                    if (guid != string.Empty) {
+                        ProjectCurator.AddAssetToDatabase(guid);
+                    }
                 });
             }
         }
@@ -58,9 +60,9 @@ namespace Ogxd.ProjectCurator
         {
             if (ProjectCuratorData.IsUpToDate) {
                 var guid = AssetDatabase.AssetPathToGUID(assetPath);
-                Actions.Enqueue(() => {
+                if (guid != string.Empty) {
                     ProjectCurator.RemoveAssetFromDatabase(guid);
-                });
+                }
             }
             return AssetDeleteResult.DidNotDelete;
         }

--- a/Editor/ProjectCurator.cs
+++ b/Editor/ProjectCurator.cs
@@ -71,10 +71,10 @@ namespace Ogxd.ProjectCurator
                             referencerAssetInfo.ClearIncludedStatus();
                         } else {
                             // Non-Reciprocity Error
-                            Debug.LogWarning($"Asset '{FormatGuid(referencer)}' that depends on '{FormatGuid(guid)}' doesn't have it as a dependency");
+                            Warn($"Asset '{FormatGuid(referencer)}' that depends on '{FormatGuid(guid)}' doesn't have it as a dependency");
                         }
                     } else {
-                        Debug.LogWarning($"Asset '{FormatGuid(referencer)}' that depends on '{FormatGuid(guid)}' is not present in the database");
+                        Warn($"Asset '{FormatGuid(referencer)}' that depends on '{FormatGuid(guid)}' is not present in the database");
                     }
                 }
                 foreach (string dependency in assetInfo.dependencies) {
@@ -83,15 +83,15 @@ namespace Ogxd.ProjectCurator
                             dependencyAssetInfo.ClearIncludedStatus();
                         } else {
                             // Non-Reciprocity Error
-                            Debug.LogWarning($"Asset '{FormatGuid(dependency)}' that is referenced by '{FormatGuid(guid)}' doesn't have it as a referencer");
+                            Warn($"Asset '{FormatGuid(dependency)}' that is referenced by '{FormatGuid(guid)}' doesn't have it as a referencer");
                         }
                     } else {
-                        Debug.LogWarning($"Asset '{FormatGuid(dependency)}' that is referenced by '{FormatGuid(guid)}' is not present in the database");
+                        Warn($"Asset '{FormatGuid(dependency)}' that is referenced by '{FormatGuid(guid)}' is not present in the database");
                     }
                 }
                 guidToAssetInfo.Remove(guid);
             } else {
-                Debug.LogWarning($"Asset '{FormatGuid(guid)}' is not present in the database");
+                Warn($"Asset '{FormatGuid(guid)}' is not present in the database");
             }
 
             return assetInfo;
@@ -156,6 +156,11 @@ namespace Ogxd.ProjectCurator
             }
             ProjectCuratorData.AssetInfos = assetInfos;
             ProjectCuratorData.Save();
+        }
+
+        static void Warn(string message)
+        {
+            Debug.LogWarning("ProjectCurator: " + message);
         }
 
         static string FormatGuid(string guid)

--- a/Editor/ProjectCurator.cs
+++ b/Editor/ProjectCurator.cs
@@ -71,10 +71,10 @@ namespace Ogxd.ProjectCurator
                             referencerAssetInfo.ClearIncludedStatus();
                         } else {
                             // Non-Reciprocity Error
-                            Debug.LogWarning($"Asset '{referencer}' that depends on '{guid}' doesn't have it as a dependency");
+                            Debug.LogWarning($"Asset '{FormatGuid(referencer)}' that depends on '{FormatGuid(guid)}' doesn't have it as a dependency");
                         }
                     } else {
-                        Debug.LogWarning($"Asset '{referencer}' that depends on '{guid}' is not present in the database");
+                        Debug.LogWarning($"Asset '{FormatGuid(referencer)}' that depends on '{FormatGuid(guid)}' is not present in the database");
                     }
                 }
                 foreach (string dependency in assetInfo.dependencies) {
@@ -83,15 +83,15 @@ namespace Ogxd.ProjectCurator
                             dependencyAssetInfo.ClearIncludedStatus();
                         } else {
                             // Non-Reciprocity Error
-                            Debug.LogWarning($"Asset '{dependency}' that is referenced by '{guid}' doesn't have it as a referencer");
+                            Debug.LogWarning($"Asset '{FormatGuid(dependency)}' that is referenced by '{FormatGuid(guid)}' doesn't have it as a referencer");
                         }
                     } else {
-                        Debug.LogWarning($"Asset '{dependency}' that is referenced by '{guid}' is not present in the database");
+                        Debug.LogWarning($"Asset '{FormatGuid(dependency)}' that is referenced by '{FormatGuid(guid)}' is not present in the database");
                     }
                 }
                 guidToAssetInfo.Remove(guid);
             } else {
-                Debug.LogWarning($"Asset '{guid}' is not present in the database");
+                Debug.LogWarning($"Asset '{FormatGuid(guid)}' is not present in the database");
             }
 
             return assetInfo;
@@ -158,7 +158,16 @@ namespace Ogxd.ProjectCurator
             ProjectCuratorData.Save();
         }
 
-        static void AssertGuidValid(string guid) {
+        static string FormatGuid(string guid)
+        {
+            var path = AssetDatabase.GUIDToAssetPath(guid);
+            return string.IsNullOrEmpty(path)
+                ? $"(Missing asset with GUID={guid})"
+                : path;
+        }
+
+        static void AssertGuidValid(string guid)
+        {
             if (string.IsNullOrEmpty(guid)) {
                 throw new ArgumentException("GUID required", nameof(guid));
             }

--- a/Editor/ProjectCurator.cs
+++ b/Editor/ProjectCurator.cs
@@ -10,39 +10,43 @@ namespace Ogxd.ProjectCurator
     public static class ProjectCurator
     {
         [NonSerialized]
-        private static Dictionary<string, AssetInfo> pathToAssetInfo;
+        private static Dictionary<string, AssetInfo> guidToAssetInfo;
 
         static ProjectCurator()
         {
-            pathToAssetInfo = new Dictionary<string, AssetInfo>();
-            var assetInfos = ProjectCuratorData.AssetInfos;
-            for (int i = 0; i < assetInfos.Length; i++) {
-                pathToAssetInfo.Add(assetInfos[i].path, assetInfos[i]);
+            guidToAssetInfo = new Dictionary<string, AssetInfo>();
+            try {
+                var assetInfos = ProjectCuratorData.AssetInfos;
+                for (int i = 0; i < assetInfos.Length; i++) {
+                    guidToAssetInfo.Add(assetInfos[i].guid, assetInfos[i]);
+                }
+            } catch (Exception e) {
+                Debug.LogError($"An error occurred while loading ProjectCurator database: {e}");
             }
         }
 
-        public static AssetInfo GetAsset(string path)
+        public static AssetInfo GetAsset(string guid)
         {
-            AssetInfo assetInfo = null;
-            pathToAssetInfo.TryGetValue(path, out assetInfo);
+            guidToAssetInfo.TryGetValue(guid, out AssetInfo assetInfo);
             return assetInfo;
         }
 
-        public static AssetInfo AddAssetToDatabase(string path, HashSet<string> referencers = null)
+        public static AssetInfo AddAssetToDatabase(string guid, HashSet<string> referencers = null)
         {
             AssetInfo assetInfo;
-            if (!pathToAssetInfo.TryGetValue(path, out assetInfo)) {
-                pathToAssetInfo.Add(path, assetInfo = new AssetInfo(path));
+            if (!guidToAssetInfo.TryGetValue(guid, out assetInfo)) {
+                guidToAssetInfo.Add(guid, assetInfo = new AssetInfo(guid));
             }
 
-            var dependencies = assetInfo.GetDependencies();
+            var dependencyPaths = assetInfo.GetDependencies();
 
-            foreach (string dependency in dependencies) {
-                if (dependency == assetInfo.path)
+            foreach (string dependencyPath in dependencyPaths) {
+                var dependencyGuid = AssetDatabase.AssetPathToGUID(dependencyPath);
+                if (dependencyGuid == assetInfo.guid)
                     continue;
-                if (pathToAssetInfo.TryGetValue(dependency, out AssetInfo depInfo)) {
-                    assetInfo.dependencies.Add(dependency);
-                    depInfo.referencers.Add(assetInfo.path);
+                if (guidToAssetInfo.TryGetValue(dependencyGuid, out AssetInfo depInfo)) {
+                    assetInfo.dependencies.Add(dependencyGuid);
+                    depInfo.referencers.Add(assetInfo.guid);
                     // Included status may have changed and need to be recomputed
                     depInfo.ClearIncludedStatus();
                 }
@@ -54,36 +58,36 @@ namespace Ogxd.ProjectCurator
             return assetInfo;
         }
 
-        public static AssetInfo RemoveAssetFromDatabase(string asset)
+        public static AssetInfo RemoveAssetFromDatabase(string guid)
         {
-            if (pathToAssetInfo.TryGetValue(asset, out AssetInfo assetInfo)) {
+            if (guidToAssetInfo.TryGetValue(guid, out AssetInfo assetInfo)) {
                 foreach (string referencer in assetInfo.referencers) {
-                    if (pathToAssetInfo.TryGetValue(referencer, out AssetInfo referencerAssetInfo)) {
-                        if (referencerAssetInfo.dependencies.Remove(asset)) {
+                    if (guidToAssetInfo.TryGetValue(referencer, out AssetInfo referencerAssetInfo)) {
+                        if (referencerAssetInfo.dependencies.Remove(guid)) {
                             referencerAssetInfo.ClearIncludedStatus();
                         } else {
                             // Non-Reciprocity Error
-                            Debug.LogWarning($"Asset '{referencer}' that depends on '{asset}' doesn't have it as a dependency");
+                            Debug.LogWarning($"Asset '{referencer}' that depends on '{guid}' doesn't have it as a dependency");
                         }
                     } else {
-                        Debug.LogWarning($"Asset '{referencer}' that depends on '{asset}' is not present in the database");
+                        Debug.LogWarning($"Asset '{referencer}' that depends on '{guid}' is not present in the database");
                     }
                 }
                 foreach (string dependency in assetInfo.dependencies) {
-                    if (pathToAssetInfo.TryGetValue(dependency, out AssetInfo dependencyAssetInfo)) {
-                        if (dependencyAssetInfo.referencers.Remove(asset)) {
+                    if (guidToAssetInfo.TryGetValue(dependency, out AssetInfo dependencyAssetInfo)) {
+                        if (dependencyAssetInfo.referencers.Remove(guid)) {
                             dependencyAssetInfo.ClearIncludedStatus();
                         } else {
                             // Non-Reciprocity Error
-                            Debug.LogWarning($"Asset '{dependency}' that is referenced by '{asset}' doesn't have it as a referencer");
+                            Debug.LogWarning($"Asset '{dependency}' that is referenced by '{guid}' doesn't have it as a referencer");
                         }
                     } else {
-                        Debug.LogWarning($"Asset '{dependency}' that is referenced by '{asset}' is not present in the database");
+                        Debug.LogWarning($"Asset '{dependency}' that is referenced by '{guid}' is not present in the database");
                     }
                 }
-                pathToAssetInfo.Remove(asset);
+                guidToAssetInfo.Remove(guid);
             } else {
-                Debug.LogWarning($"Asset '{asset}' is not present in the database");
+                Debug.LogWarning($"Asset '{guid}' is not present in the database");
             }
 
             return assetInfo;
@@ -91,36 +95,42 @@ namespace Ogxd.ProjectCurator
 
         public static void ClearDatabase()
         {
-            pathToAssetInfo.Clear();
+            guidToAssetInfo.Clear();
         }
 
         public static void RebuildDatabase()
         {
-            pathToAssetInfo = new Dictionary<string, AssetInfo>();
+            guidToAssetInfo = new Dictionary<string, AssetInfo>();
 
             var allAssetPaths = AssetDatabase.GetAllAssetPaths();
 
             // Ignore non-assets (package folder for instance) and directories
-            allAssetPaths = allAssetPaths.Where(x => x.StartsWith("Assets/") && !Directory.Exists(x)).ToArray();
+            allAssetPaths = allAssetPaths
+                .Where(path => path.StartsWith("Assets/") && !Directory.Exists(path))
+                .ToArray();
 
             EditorUtility.DisplayProgressBar("Building Dependency Database", "Gathering All Assets...", 0f);
 
             // Gather all assets
             for (int p = 0; p < allAssetPaths.Length; p++) {
-                AssetInfo assetInfo = new AssetInfo(allAssetPaths[p]);
-                pathToAssetInfo.Add(assetInfo.path, assetInfo);
+                string path = allAssetPaths[p];
+                string guid = AssetDatabase.AssetPathToGUID(path);
+                AssetInfo assetInfo = new AssetInfo(guid);
+                guidToAssetInfo.Add(assetInfo.guid, assetInfo);
             }
 
             // Find links between assets
             for (int p = 0; p < allAssetPaths.Length; p++) {
+                var path = allAssetPaths[p];
                 if (p % 10 == 0) {
-                    var cancel = EditorUtility.DisplayCancelableProgressBar("Building Dependency Database", allAssetPaths[p], (float)p / allAssetPaths.Length);
+                    var cancel = EditorUtility.DisplayCancelableProgressBar("Building Dependency Database", path, (float)p / allAssetPaths.Length);
                     if (cancel) {
-                        pathToAssetInfo = null;
+                        guidToAssetInfo = null;
                         break;
                     }
                 }
-                AddAssetToDatabase(allAssetPaths[p]);
+                string guid = AssetDatabase.AssetPathToGUID(path);
+                AddAssetToDatabase(guid);
             }
 
             EditorUtility.ClearProgressBar();
@@ -132,11 +142,11 @@ namespace Ogxd.ProjectCurator
 
         public static void SaveDatabase()
         {
-            if (pathToAssetInfo == null)
+            if (guidToAssetInfo == null)
                 return;
-            var assetInfos = new AssetInfo[pathToAssetInfo.Count];
+            var assetInfos = new AssetInfo[guidToAssetInfo.Count];
             int i = 0;
-            foreach (var pair in pathToAssetInfo) {
+            foreach (var pair in guidToAssetInfo) {
                 assetInfos[i] = pair.Value;
                 i++;
             }

--- a/Editor/ProjectCurator.cs
+++ b/Editor/ProjectCurator.cs
@@ -40,13 +40,15 @@ namespace Ogxd.ProjectCurator
                 guidToAssetInfo.Add(guid, assetInfo = new AssetInfo(guid));
             }
 
-            var dependencyPaths = assetInfo.GetDependencies();
+            var path = AssetDatabase.GUIDToAssetPath(guid);
+            var dependencyPaths = AssetDatabase.GetDependencies(path, recursive: false);
 
             foreach (string dependencyPath in dependencyPaths) {
                 var dependencyGuid = AssetDatabase.AssetPathToGUID(dependencyPath);
-                if (dependencyGuid == assetInfo.guid)
-                    continue;
-                if (guidToAssetInfo.TryGetValue(dependencyGuid, out AssetInfo depInfo)) {
+                if (
+                    dependencyGuid != assetInfo.guid &&
+                    guidToAssetInfo.TryGetValue(dependencyGuid, out AssetInfo depInfo)
+                ) {
                     assetInfo.dependencies.Add(dependencyGuid);
                     depInfo.referencers.Add(assetInfo.guid);
                     // Included status may have changed and need to be recomputed

--- a/Editor/ProjectCurator.cs
+++ b/Editor/ProjectCurator.cs
@@ -33,6 +33,8 @@ namespace Ogxd.ProjectCurator
 
         public static AssetInfo AddAssetToDatabase(string guid, HashSet<string> referencers = null)
         {
+            AssertGuidValid(guid);
+
             AssetInfo assetInfo;
             if (!guidToAssetInfo.TryGetValue(guid, out assetInfo)) {
                 guidToAssetInfo.Add(guid, assetInfo = new AssetInfo(guid));
@@ -60,6 +62,8 @@ namespace Ogxd.ProjectCurator
 
         public static AssetInfo RemoveAssetFromDatabase(string guid)
         {
+            AssertGuidValid(guid);
+
             if (guidToAssetInfo.TryGetValue(guid, out AssetInfo assetInfo)) {
                 foreach (string referencer in assetInfo.referencers) {
                     if (guidToAssetInfo.TryGetValue(referencer, out AssetInfo referencerAssetInfo)) {
@@ -152,6 +156,12 @@ namespace Ogxd.ProjectCurator
             }
             ProjectCuratorData.AssetInfos = assetInfos;
             ProjectCuratorData.Save();
+        }
+
+        static void AssertGuidValid(string guid) {
+            if (string.IsNullOrEmpty(guid)) {
+                throw new ArgumentException("GUID required", nameof(guid));
+            }
         }
     }
 }

--- a/Editor/ProjectWindowOverlay.cs
+++ b/Editor/ProjectWindowOverlay.cs
@@ -15,12 +15,10 @@ namespace Ogxd.ProjectCurator
         private static void ProjectWindowItemOnGUI(string guid, Rect rect)
         {
             if (enabled) {
-                AssetInfo assetInfo = ProjectCurator.GetAsset(AssetDatabase.GUIDToAssetPath(guid));
+                AssetInfo assetInfo = ProjectCurator.GetAsset(guid);
                 if (assetInfo != null) {
                     var content = new GUIContent(assetInfo.IsIncludedInBuild ? ProjectIcons.LinkBlue : ProjectIcons.LinkBlack, assetInfo.IncludedStatus.ToString());
                     GUI.Label(new Rect(rect.width + rect.x - 20, rect.y + 1, 16, 16), content);
-                } else {
-
                 }
             }
         }


### PR DESCRIPTION
Hey @ogxd. I've switched all storage of paths to GUID and it seems to work well (and fixes #15).

~~**Please don't merge yet!**~~

~~I haven't given it a super thorough test, but I thought I'd share now in case you have any feedback.~~

~~Biggest issue is that the warnings now all log out GUIDs instead of readable file paths.~~

~~This is my plan for warnings~~

TODO:
- [x] `AssetModificationProcessor` should pass paths, not GUIDs, then the warnings will have the correct name for the files changing.
- [x] In the case of dependencies/referencers, if they still exist then we should be able to use `AssetDatabase.GUIDToAssetPath` to render the correct string.
- [x] In the case that we have a GUID that references a non-existent asset, just write "Missing asset (\<GUID>)" or similar. Slightly worse but those warnings are really just there for debugging this tool, not for the end user.

Anyway, let me know what you think.