### PR TITLE
Fix warning when deleting empty folders

### DIFF
--- a/Editor/AssetProcessor.cs
+++ b/Editor/AssetProcessor.cs
@@ -46,6 +46,14 @@ namespace Ogxd.ProjectCurator
 
         static void OnWillCreateAsset(string assetPath)
         {
+            // Due to an apparent bug in Unity, newly created folders give the
+            // path of the meta file, instead of the folder itself. Trim the
+            // .meta off the end in the case that this happens.
+            //
+            // .meta files are not assets, so there are no other cases where
+            // this will have any effect.
+            assetPath = assetPath.TrimEnd(".meta");
+
             if (ProjectCuratorData.IsUpToDate) {
                 _actions.Enqueue(() => {
                     var guid = AssetDatabase.AssetPathToGUID(assetPath);

--- a/Editor/StringUtility.cs
+++ b/Editor/StringUtility.cs
@@ -1,18 +1,18 @@
 using System;
 
 namespace Ogxd.ProjectCurator {
-  internal static class StringUtility
-  {
-    // https://stackoverflow.com/a/7170953/317135
-    public static string TrimEnd(
-      this string input,
-      string suffixToRemove,
-      StringComparison comparisonType = StringComparison.CurrentCulture
-    ) {
-      if (suffixToRemove != null && input.EndsWith(suffixToRemove, comparisonType)) {
-        return input[0..^suffixToRemove.Length];
-      }
-      return input;
+    internal static class StringUtility
+    {
+        // https://stackoverflow.com/a/7170953/317135
+        public static string TrimEnd(
+            this string input,
+            string suffixToRemove,
+            StringComparison comparisonType = StringComparison.CurrentCulture) 
+        {
+            if (suffixToRemove != null && input.EndsWith(suffixToRemove, comparisonType)) {
+                return input[0..^suffixToRemove.Length];
+            }
+            return input;
+        }
     }
-  }
 }

--- a/Editor/StringUtility.cs
+++ b/Editor/StringUtility.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Ogxd.ProjectCurator {
+  internal static class StringUtility
+  {
+    // https://stackoverflow.com/a/7170953/317135
+    public static string TrimEnd(
+      this string input,
+      string suffixToRemove,
+      StringComparison comparisonType = StringComparison.CurrentCulture
+    ) {
+      if (suffixToRemove != null && input.EndsWith(suffixToRemove, comparisonType)) {
+        return input[0..^suffixToRemove.Length];
+      }
+      return input;
+    }
+  }
+}

--- a/Editor/StringUtility.cs.meta
+++ b/Editor/StringUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b96c43eb83e84d74db9393322ded985f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Closes #21 
Closes #16 

This was caused by a bug in Unity where an incorrect path was being passed to `OnWillCreateAsset`. For folders the path for the meta file was given, instead of the actual folder path. Because the meta file is not an asset, its guid would be zero. When deleting the folder, the correct path is given.

I also did a small tidy on `AssetProcessor`.

Note that I tested this change with @ogxd's refactor branch, and it has no conflicts. (See #22)