### PR TITLE
Move persisted data

### DIFF
--- a/Editor/ProjectCuratorData.cs
+++ b/Editor/ProjectCuratorData.cs
@@ -11,7 +11,10 @@ namespace Ogxd.ProjectCurator
 
         [SerializeField]
         private bool isUpToDate = false;
-        public static bool IsUpToDate { get { return Instance.isUpToDate; } set { Instance.isUpToDate = value; } }
+        public static bool IsUpToDate {
+            get => Instance.isUpToDate;
+            set => Instance.isUpToDate = value;
+        }
 
         [SerializeField]
         private AssetInfo[] assetInfos;

--- a/Editor/ProjectCuratorData.cs
+++ b/Editor/ProjectCuratorData.cs
@@ -7,7 +7,7 @@ namespace Ogxd.ProjectCurator
     [Serializable]
     public class ProjectCuratorData
     {
-        private const string JSON_PATH = "ProjectSettings/ProjectCuratorSettings.json";
+        private const string JSON_PATH = "UserSettings/ProjectCuratorData.json";
 
         [SerializeField]
         private bool isUpToDate = false;


### PR DESCRIPTION
Closes #18 

This moves the saved data into the UserSettings folder, saving users from needing to explicitly add the file to their .gitignore (since UserSettings is not to be included in version control).